### PR TITLE
Fred/fix/multi bill user request

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,7 +35,12 @@ const App = (props) => {
       const response = await axios.get(
         `${process.env.REACT_APP_COMMONS_API}/bills`
       );
-      setBills(response.data.bills);
+
+      const sortedBills = response.data.bills.sort(
+        (a, b) => new Date(b.introduced_date) - new Date(a.introduced_date)
+      );
+
+      setBills(sortedBills);
       setCategories(response.data.categories);
       doneLoading();
     } catch (error) {
@@ -95,16 +100,19 @@ const App = (props) => {
   };
 
   const handleLogout = () => {
+    updateLoadingState(true);
     axios
       .delete(`${process.env.REACT_APP_COMMONS_API}/logout`)
       .then(() => {
         setUser(null);
         setLoggedIn(false);
         props.history.push('/');
+        updateLoadingState(false);
       })
-      .catch((error) =>
-        console.error(`Error occurred on handleProfileUpdate: ${error}`)
-      );
+      .catch((error) => {
+        updateLoadingState(false);
+        console.error(`Error occurred on handleProfileUpdate: ${error}`);
+      });
   };
 
   // For components to call when they render to remove loading spinner

--- a/src/App.js
+++ b/src/App.js
@@ -42,7 +42,7 @@ const App = (props) => {
 
       setBills(sortedBills);
       setCategories(response.data.categories);
-      doneLoading();
+      updateLoadingState(false);
     } catch (error) {
       console.error('Error occurred on fetchBills:', error);
     }
@@ -113,11 +113,6 @@ const App = (props) => {
         updateLoadingState(false);
         console.error(`Error occurred on handleProfileUpdate: ${error}`);
       });
-  };
-
-  // For components to call when they render to remove loading spinner
-  const doneLoading = () => {
-    updateLoadingState(false);
   };
 
   return (

--- a/src/App.js
+++ b/src/App.js
@@ -67,7 +67,10 @@ const App = (props) => {
         }
       );
       if (res.data.status === 200) {
-        setUser(res.data.user);
+        // back end is only returning the user data and their categories, keep the old
+        // user_bills (aka watchlist)
+        // Other option is to have the API server return the user's bill
+        setUser((prev) => ({ ...res.data.user, user_bills: prev.user_bills }));
       } else {
         console.error(
           `Error occurred on handleProfileUpdate: ${res.data.errors}`

--- a/src/views/HomePage/BillCard.js
+++ b/src/views/HomePage/BillCard.js
@@ -44,26 +44,26 @@ const useStyles = makeStyles((theme) => ({
     boxShadow: '10px 17px 24px -13px rgba(0,0,0,0.5)',
     marginRight: '5%',
     marginTop: '5%',
-    marginBottom: '5%'
+    marginBottom: '5%',
   },
   title: {
     paddingTop: '3%',
-    fontSize: '1.5vw'
+    fontSize: '1.5vw',
   },
   introduced: {
-    fontSize: '1.25vw'
+    fontSize: '1.25vw',
   },
   description: {
     paddingTop: '2%',
-    fontSize: '1.25vw'
+    fontSize: '1.25vw',
   },
   billButtons: {
     width: '128px',
-    marginTop: '10px'
+    marginTop: '10px',
   },
   event: {
-    fontSize: '1.25vw'
-  }
+    fontSize: '1.25vw',
+  },
 }));
 
 const button = {
@@ -71,7 +71,7 @@ const button = {
   boxShadow: 'inset 0 0 20px rgba(255, 255, 255,0)',
   boxShadow: '7px 7px 15px rgba(55, 84, 170,.15)',
   boxShadow: '-7px -7px 20px rgba(255, 255, 255,1)',
-  boxShadow: 'inset 0px 0px 4px rgba(255, 255, 255,.2)'
+  boxShadow: 'inset 0px 0px 4px rgba(255, 255, 255,.2)',
 };
 
 /**
@@ -92,27 +92,12 @@ export default function BillCard(props) {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    props.user && findWatchedBills(props.user.id);
     props.user &&
     props.user.user_bills &&
     props.user.user_bills.includes(props.bill.id)
       ? setColor('red')
       : setColor('grey');
   }, []);
-
-  const findWatchedBills = async (user_id) => {
-    try {
-      const response = await axios.get(
-        `${process.env.REACT_APP_COMMONS_API}/bills/${user_id}`
-      );
-      let watchedBills = response.data.user_bills;
-      if (watchedBills.includes(props.bill.id)) {
-        setColor('red');
-      }
-    } catch (error) {
-      console.error(`Error occurred on findWatchedBills: ${error}`);
-    }
-  };
 
   const handleWatchSubmit = async () => {
     const watchlist_bill = {
@@ -285,7 +270,7 @@ export default function BillCard(props) {
                   <Snackbar
                     anchorOrigin={{
                       vertical: 'bottom',
-                      horizontal: 'center'
+                      horizontal: 'center',
                     }}
                     open={open}
                     autoHideDuration={2000}

--- a/src/views/HomePage/Bills.js
+++ b/src/views/HomePage/Bills.js
@@ -8,13 +8,7 @@ export default function Bills(props) {
       : bill.categories.includes(props.childCategory);
   });
 
-  const sortedBills = bills.sort(
-    (a, b) => b.introduced_date - a.introduced_date
-  );
-
-  console.log(sortedBills);
-
-  const billCards = sortedBills.map((bill) => {
+  const billCards = bills.map((bill) => {
     return (
       <BillCard
         user={props.user}


### PR DESCRIPTION
- The PUT call to the API server to update the user doesn't return the
user's watchlist (user.user_bills in React code)
- Keeping previous watched bills in the front end instead of having the
API server send it back
  - reduces extra query on back end
  - that data didn't change when doing the update

- reduce sorting many times (i.e. evertime we render bills)